### PR TITLE
Support reading issues from multiple organizations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,9 @@ orgs:
       - junipernetworks.junos
       - cisco.asa
       - ansible.netcommon
+  - name: ansible
+    repos:
+      - pylibssh
 maintainers:
   - name: Nilashish Chakraborty
     email: abc@test.local

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,15 @@
-org: ansible-collections
-repos:
-  - cisco.nxos
-  - cisco.ios
-  - cisco.iosxr
-  - arista.eos
-  - vyos.vyos
-  - junipernetworks.junos
-  - cisco.asa
-  - ansible.netcommon
+---
+orgs:
+  - name: ansible-collections
+    repos:
+      - cisco.nxos
+      - cisco.ios
+      - cisco.iosxr
+      - arista.eos
+      - vyos.vyos
+      - junipernetworks.junos
+      - cisco.asa
+      - ansible.netcommon
 maintainers:
   - name: Nilashish Chakraborty
     email: abc@test.local

--- a/triager.py
+++ b/triager.py
@@ -1,5 +1,5 @@
-import os
 from datetime import datetime, timedelta
+import os
 
 import requests
 import yaml
@@ -16,8 +16,10 @@ class Triager:
             config = yaml.safe_load(config_file)
 
         # Populate org and repos to triage
-        self.org = config["org"]
-        self.repos = config["repos"]
+        self.repos = []
+        for org in config["orgs"]:
+            for repo in org["repos"]:
+                self.repos.append((org["name"], repo))
 
         # Populate maintainers list
         self.maintainers = config["maintainers"]
@@ -32,10 +34,10 @@ class Triager:
 
     def triage(self):
         issues = {}
-        for repo in self.repos:
+        for org, repo in self.repos:
             issues[repo] = []
             resp = requests.get(
-                REQUEST_FMT.format(self.org, repo),
+                REQUEST_FMT.format(org, repo),
                 params={"status": "open"},
                 headers=self._get_token(),
             )


### PR DESCRIPTION
Pretty straightforward, we may at some point like to triage issues from different orgs, such as the pylibssh repository.