### PR TITLE
Return only those issues that were created within the specified timedelta

### DIFF
--- a/triager/__main__.py
+++ b/triager/__main__.py
@@ -56,7 +56,7 @@ def main():
         help="save logging information to a file",
     )
     group.add_argument(
-        "--log", action="store_true", help="display logging data on console",
+        "--log", action="store_true", help="display logging data on console"
     )
 
     parser.add_argument(
@@ -70,7 +70,7 @@ def main():
     )
 
     group.add_argument(
-        "--version", action="store_true", help="show version number",
+        "--version", action="store_true", help="show version number"
     )
 
     args = parser.parse_args()

--- a/triager/config.py
+++ b/triager/config.py
@@ -50,9 +50,13 @@ class Config:
                     "password": config["triager"]["password"],
                 }
             except KeyError as exc:
-                logging.error(f"triager config malformed, key {exc!s} not found")
+                logging.error(
+                    f"triager config malformed, key {exc!s} not found"
+                )
             except TypeError:
-                logging.error("triager config malformed, should be a dictionary")
+                logging.error(
+                    "triager config malformed, should be a dictionary"
+                )
         else:
             logging.debug("triager not found in config, will not send email")
 

--- a/triager/triager.py
+++ b/triager/triager.py
@@ -1,7 +1,7 @@
 import logging
+from datetime import datetime
 
 import requests
-
 
 REQUEST_FMT = "https://api.github.com/repos/{0}/{1}/issues"
 
@@ -34,15 +34,19 @@ def triage(config):
             return {}
 
         for item in resp.json():
-            issues[repo_name].append(
-                {
-                    "url": item["html_url"],
-                    "title": item["title"],
-                    "type": "Pull Request"
-                    if item.get("pull_request")
-                    else "Issue",
-                }
+            created_at = datetime.strptime(
+                item["created_at"], "%Y-%m-%dT%H:%M:%SZ"
             )
+            if created_at >= config.last_triage_date:
+                issues[repo_name].append(
+                    {
+                        "url": item["html_url"],
+                        "title": item["title"],
+                        "type": "Pull Request"
+                        if item.get("pull_request")
+                        else "Issue",
+                    }
+                )
 
     logging.info("triage successfully completed")
     return issues


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

* Calling the API with `since` param returns both newly created
  issues and issues that were updated within the specified `timedelta`

* This causes repetition of previously triaged issues.

* This commit further filters the issues/PRs returned by the API
  and populates the table with only those that were newly created.